### PR TITLE
TemplateTagTestCase added

### DIFF
--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -231,6 +231,12 @@ class TemplateTagTestCase(SaneTestCase):
         """
         Render the given template string with user-defined tag modules
         pre-loaded.
+
+        Attributes
+        * `preload' defines which template tag libraries are to be loaded
+          before rendering the actual template string
+        * `TemplateSyntaxError' is bundled within this class, so that nothing
+          from django.template must be imported in most cases
         """
 
         loads = u''

--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -224,19 +224,24 @@ class SeleniumTestCase(HttpTestCase):
 
 
 class TemplateTagTestCase(SaneTestCase):
+    """
+    Allow for sane and comfortable template tag unit-testing.
+
+    Attributes:
+    * `preload' defines which template tag libraries are to be loaded
+      before rendering the actual template string
+    * `TemplateSyntaxError' is bundled within this class, so that nothing
+      from django.template must be imported in most cases of template
+      tag testing
+    """
+
     TemplateSyntaxError = TemplateSyntaxError
     preload = ()
 
-    def _render_template(self, template, **kwargs):
+    def render_template(self, template, **kwargs):
         """
         Render the given template string with user-defined tag modules
-        pre-loaded.
-
-        Attributes
-        * `preload' defines which template tag libraries are to be loaded
-          before rendering the actual template string
-        * `TemplateSyntaxError' is bundled within this class, so that nothing
-          from django.template must be imported in most cases
+        pre-loaded (according to the class attribute `preload').
         """
 
         loads = u''

--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -2,7 +2,7 @@ import re
 import sys
 import urllib2
 
-from django import template
+from django.template import Context, Template, TemplateSyntaxError
 from nose.tools import (
                 assert_equals,
                 assert_almost_equals,
@@ -224,10 +224,10 @@ class SeleniumTestCase(HttpTestCase):
 
 
 class TemplateTagTestCase(SaneTestCase):
-    TemplateSyntaxError = template.TemplateSyntaxError
+    TemplateSyntaxError = TemplateSyntaxError
     preload = ()
 
-    def _render_template(self, tmpl, **kwargs):
+    def _render_template(self, template, **kwargs):
         """
         Render the given template string with user-defined tag modules
         pre-loaded.
@@ -237,5 +237,5 @@ class TemplateTagTestCase(SaneTestCase):
         for load in self.preload:
             loads = u''.join([loads, '{% load ', load, ' %}'])
 
-        tmpl = u''.join([loads, tmpl])
-        return template.Template(tmpl).render(template.Context(kwargs))
+        template = u''.join([loads, template])
+        return Template(template).render(Context(kwargs))

--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -41,7 +41,7 @@ class SaneTestCase(object):
 
         caps = re.compile('([A-Z])')
         
-        from unittest import TestCase
+        from django.test import TestCase
         
         ##########
         ### Scraping heavily inspired by nose testing framework, (C) by Jason Pellerin

--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -223,7 +223,7 @@ class SeleniumTestCase(HttpTestCase):
     test_type = "selenium"
 
 
-class TemplateTagTestCase(SaneTestCase):
+class TemplateTagTestCase(UnitTestCase):
     """
     Allow for sane and comfortable template tag unit-testing.
 

--- a/djangosanetesting/cases.py
+++ b/djangosanetesting/cases.py
@@ -2,6 +2,7 @@ import re
 import sys
 import urllib2
 
+from django import template
 from nose.tools import (
                 assert_equals,
                 assert_almost_equals,
@@ -14,7 +15,8 @@ from nose import SkipTest
 
 from djangosanetesting.utils import twill_patched_go, twill_xpath_go, extract_django_traceback
 
-__all__ = ("UnitTestCase", "DatabaseTestCase", "DestructiveDatabaseTestCase", "HttpTestCase", "SeleniumTestCase")
+__all__ = ("UnitTestCase", "DatabaseTestCase", "DestructiveDatabaseTestCase",
+           "HttpTestCase", "SeleniumTestCase", "TemplateTagTestCase")
 
 class SaneTestCase(object):
     """ Common ancestor we're using our own hierarchy """
@@ -220,3 +222,20 @@ class SeleniumTestCase(HttpTestCase):
     selenium_plugin_started = False
     test_type = "selenium"
 
+
+class TemplateTagTestCase(SaneTestCase):
+    TemplateSyntaxError = template.TemplateSyntaxError
+    preload = ()
+
+    def _render_template(self, tmpl, **kwargs):
+        """
+        Render the given template string with user-defined tag modules
+        pre-loaded.
+        """
+
+        loads = u''
+        for load in self.preload:
+            loads = u''.join([loads, '{% load ', load, ' %}'])
+
+        tmpl = u''.join([loads, tmpl])
+        return template.Template(tmpl).render(template.Context(kwargs))

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -21,6 +21,7 @@ Various test types were identified when taking look at :ref:`developer tests <de
 * :class:`DestructiveDatabaseTestCase`
 * :class:`HttpTestCase`
 * :class:`SeleniumTestCase`
+* :class:`TemplateTagTestCase`
 
 However, you are not *required* to inherit from those (except for :ref:`twill <twill-integration>`), althrough it's much advised to keep test cases intent-revealing. Job of the library is to:
 
@@ -44,11 +45,12 @@ Proper defaults are selected when using :ref:`library test cases <list-of-test-c
 
 When writing tests, keep in mind limitations of the individual test cases to prevent interacting tests:
 
-* :class:`UnitTestCase` should not interact with database or server frontend
-* :class:`DatabaseTestCase` must run in one transaction and thus cannot be multithreaded and must not call commit
-* :class:`DestructiveDatabaseTestCase` is slow and do not have live server available (cannot test using urllib2 and friends)
+* :class:`UnitTestCase` should not interact with database or server frontend.
+* :class:`DatabaseTestCase` must run in one transaction and thus cannot be multithreaded and must not call commit.
+* :class:`DestructiveDatabaseTestCase` is slow and do not have live server available (cannot test using urllib2 and friends).
 * :class:`HttpTestCase` provides all goodies except Selenium. When first encountered, live server is spawned; after that, it's as fast as :class:`DestructiveDatabaseTestCase`.
 * :class:`SeleniumTestCase` has it all (except speed).
+* :class:`TemplateTagTestCase` provides helper methods for testing custom template tags and filters.
 
 
 .. _running-tests:

--- a/testproject/test/test_templatetag.py
+++ b/testproject/test/test_templatetag.py
@@ -4,54 +4,49 @@ class TestTagLib(TemplateTagTestCase):
     preload = ('dsttesttags',)
 
     def test_tag_error(self):
-        self.assertRaisesRegexp(self.TemplateSyntaxError,
-            r'Not enough arguments for \'table\'',
-            self._render_template, '{% table %}')
+        self.assert_raises(self.TemplateSyntaxError, self.render_template,
+                           '{% table %}')
 
     def test_tag_output(self):
-        self.assertEqual(self._render_template('''{% table x_y z %}'''),
+        self.assert_equal(self.render_template('{% table x_y z %}'),
             u'<table><tr><td>x</td><td>y</td></tr><tr><td>z</td></tr></table>')
 
 class TestFilterLib(TemplateTagTestCase):
-    preload = ('filters',)
+    preload = ('dsttestfilters',)
 
     def test_filter_output(self):
-        self.assertEqual(self._render_template('{{ a|ihatebs }}', a='abc'),
+        self.assert_equal(self.render_template('{{ a|ihatebs }}', a='abc'),
                          u'aac')
 
 class TestBoth(TestTagLib, TestFilterLib):
     preload = ('dsttesttags', 'dsttestfilters')
 
-    def _call_render(self):
-        return self._render_template('{% table b %}{{ a|ihatebs }}',
+    def _call_test_render(self):
+        return self.render_template('{% table b %}{{ a|ihatebs }}',
                                      a='a_bb_d b')
 
     def test_both_output(self):
-        self.assertEqual(self._call_render(), u'<table><tr><td>b</td></tr>'
+        self.assert_equal(self._call_test_render(), u'<table><tr><td>b</td></tr>'
                          '</table>a_aa_d a')
 
     def test_preload_none(self):
         self.preload = ()
-        self.assertRaisesRegexp(self.TemplateSyntaxError,
-            r'Invalid block tag: \'table\'', self._call_render)
+        self.assert_raises(self.TemplateSyntaxError, self._call_test_render)
 
     def test_preload_tags_only(self):
         self.preload = ('dsttesttags',)
-        self.assertRaisesRegexp(self.TemplateSyntaxError,
-            r'Invalid filter: \'ihatebs\'', self._call_render)
+        self.assert_raises(self.TemplateSyntaxError, self._call_test_render)
 
     def test_preload_filters_only(self):
         self.preload = ('dsttestfilters',)
-        self.assertRaisesRegexp(self.TemplateSyntaxError,
-            r'Invalid block tag: \'table\'', self._call_render)
+        self.assert_raises(self.TemplateSyntaxError, self._call_test_render)
 
 class TestMisc(TemplateTagTestCase):
     def test_context(self):
-        self.assertEqual(self._render_template('{{ cvar }}'), u'')
-        self.assertEqual(self._render_template('{{ cvar }}', cvar=123), u'123')
+        self.assert_equal(self.render_template('{{ cvar }}'), u'')
+        self.assert_equal(self.render_template('{{ cvar }}', cvar=123), u'123')
 
     def test_nonexistent_taglib(self):
         self.preload = ('nonexistent',)
-        self.assertRaisesRegexp(self.TemplateSyntaxError,
-                                r'\'nonexistent\' is not a valid tag library',
-                                self._render_template, 'sthing')
+        self.assert_raises(self.TemplateSyntaxError, self.render_template,
+                           'sthing')

--- a/testproject/test/test_templatetag.py
+++ b/testproject/test/test_templatetag.py
@@ -1,0 +1,57 @@
+from djangosanetesting.cases import TemplateTagTestCase
+
+class TestTagLib(TemplateTagTestCase):
+    preload = ('dsttesttags',)
+
+    def test_tag_error(self):
+        self.assertRaisesRegexp(self.TemplateSyntaxError,
+            r'Not enough arguments for \'table\'',
+            self._render_template, '{% table %}')
+
+    def test_tag_output(self):
+        self.assertEqual(self._render_template('''{% table x_y z %}'''),
+            u'<table><tr><td>x</td><td>y</td></tr><tr><td>z</td></tr></table>')
+
+class TestFilterLib(TemplateTagTestCase):
+    preload = ('filters',)
+
+    def test_filter_output(self):
+        self.assertEqual(self._render_template('{{ a|ihatebs }}', a='abc'),
+                         u'aac')
+
+class TestBoth(TestTagLib, TestFilterLib):
+    preload = ('dsttesttags', 'dsttestfilters')
+
+    def _call_render(self):
+        return self._render_template('{% table b %}{{ a|ihatebs }}',
+                                     a='a_bb_d b')
+
+    def test_both_output(self):
+        self.assertEqual(self._call_render(), u'<table><tr><td>b</td></tr>'
+                         '</table>a_aa_d a')
+
+    def test_preload_none(self):
+        self.preload = ()
+        self.assertRaisesRegexp(self.TemplateSyntaxError,
+            r'Invalid block tag: \'table\'', self._call_render)
+
+    def test_preload_tags_only(self):
+        self.preload = ('dsttesttags',)
+        self.assertRaisesRegexp(self.TemplateSyntaxError,
+            r'Invalid filter: \'ihatebs\'', self._call_render)
+
+    def test_preload_filters_only(self):
+        self.preload = ('dsttestfilters',)
+        self.assertRaisesRegexp(self.TemplateSyntaxError,
+            r'Invalid block tag: \'table\'', self._call_render)
+
+class TestMisc(TemplateTagTestCase):
+    def test_context(self):
+        self.assertEqual(self._render_template('{{ cvar }}'), u'')
+        self.assertEqual(self._render_template('{{ cvar }}', cvar=123), u'123')
+
+    def test_nonexistent_taglib(self):
+        self.preload = ('nonexistent',)
+        self.assertRaisesRegexp(self.TemplateSyntaxError,
+                                r'\'nonexistent\' is not a valid tag library',
+                                self._render_template, 'sthing')

--- a/testproject/testapp/templatetags/dsttestfilters.py
+++ b/testproject/testapp/templatetags/dsttestfilters.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def ihatebs(value):
+    return value.replace('b', 'a')

--- a/testproject/testapp/templatetags/dsttesttags.py
+++ b/testproject/testapp/templatetags/dsttesttags.py
@@ -1,0 +1,27 @@
+from django import template
+
+register = template.Library()
+
+class TableNode(template.Node):
+    root_tmpl = u'<table>%s</table>'
+    row_tmpl = u'<tr>%s</tr>'
+    cell_tmpl = u'<td>%s</td>'
+
+    def __init__(self, data):
+        self.data = data
+
+    def render(self, context):
+        row_res = []
+        for row in self.data:
+            cell_res = []
+            for cell in row:
+                cell_res.append(self.cell_tmpl % cell)
+            row_res.append(self.row_tmpl % u''.join(cell_res))
+        return self.root_tmpl % u''.join(row_res)
+
+@register.tag
+def table(parser, token):
+    args = token.contents.split()[1:]
+    if len(args) < 1:
+        raise template.TemplateSyntaxError("Not enough arguments for 'table'")
+    return TableNode([arg.split('_') for arg in args])


### PR DESCRIPTION
As we have already talked about this functionality, here is the patch. Bundles TemplateSyntaxError as well and therefore nothing from django.template must be imported in most cases when testing template tags and filters.

Thanks.
