### PR TITLE
Updated repository URL to github in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ Django: Sane Testing
 
 Welcome to library that allows you to really test your Django applications. Read :ref:`introduction <intro>` if you're intrested in my motivations and an overview of what this library do; look at :ref:`test introduction <test-intro>` if you want to know my approach to web testing (fundamental to project design) or proceed directly to :ref:`Usage <usage>` to start using it, or :ref:`plugin description <plugins>` if you're experienced testing/nose coder and just want the plugin reference.
 
-Trac is available at `my devel pages <http://devel.almad.net/trac/django-sane-testing/>`_ and downloads available from `releases <http://devel.almad.net/trac/django-sane-testing/wiki/Releases>`_. Those interested can also always grab code directly from `repository <http://devel.almad.net/hg/django-sane-testing/>`_ or `track project at ohloh <http://www.ohloh.net/p/django-sane-testing>`_.
+Trac is available at `my devel pages <http://devel.almad.net/trac/django-sane-testing/>`_ and downloads available from `releases <http://devel.almad.net/trac/django-sane-testing/wiki/Releases>`_. Those interested can also always grab code directly from `repository <https://github.com/Almad/django-sane-testing>`_ or `track project at ohloh <http://www.ohloh.net/p/django-sane-testing>`_.
 
 Feedback is always appreciated. Send it to bugs at almad.net, I'll be glad to hear from you.
 


### PR DESCRIPTION
Here's a minor change.  The repository URL in the documentation was pointing to a seemingly defunct location (returns a 500).  This change makes it point to this github repository.
